### PR TITLE
alias the profile_count_update services method

### DIFF
--- a/devopshobbies/users/tasks.py
+++ b/devopshobbies/users/tasks.py
@@ -1,10 +1,10 @@
 from celery import shared_task
-from .services import profile_count_update
+from .services import profile_count_update as update_profile_count
 
 
 @shared_task
 def profile_count_update():
-    profile_count_update()
+    update_profile_count()
 
 @shared_task
 def hello2():


### PR DESCRIPTION
The profile_count_update service method is aliased so that it does not have the same name as the celery shared_task